### PR TITLE
More files accepted as torrents by is_torrent().

### DIFF
--- a/Torrent.php
+++ b/Torrent.php
@@ -802,7 +802,11 @@ class Torrent {
 	 * @return boolean is the file a torrent or not
 	 */
 	static public function is_torrent ( $file, $timeout = self::timeout ) {
-		return ( $start = self::file_get_contents( $file, $timeout, 0, 11 ) ) &&  $start === 'd8:announce' || $start === 'd10:created';
+		return ( $start = self::file_get_contents( $file, $timeout, 0, 11 ) )
+			 && $start === 'd8:announce'
+			 || $start === 'd10:created'
+			 || $start === 'd13:creatio'
+			 || substr($start, 0, 3) === 'd9:';
 	}
 
 	/** Helper to get (distant) file content


### PR DESCRIPTION
Some torrents files observed online start with "d13:creation date". Some files starting with "d9:\0*\0errorsle8:announce" where also observed.

This commit adds these cases to is_torrent(). To avoid problems with binary 0s, only the 3 first bytes "d9:" are compared for the last case. Files with binary zeros in the first 11 bytes are now accepted as torrents but still cause bugs in other places.

Fix some occurences of bug https://github.com/adriengibrat/torrent-rw/issues/15 .
