### PR TITLE
Fix PHP 8 mixed type issue

### DIFF
--- a/Torrent.php
+++ b/Torrent.php
@@ -967,7 +967,7 @@ class Torrent
             $size /= 1024;
         }
 
-        return round($size, $precision) . ' ' . ($next ? prev($units) : end($units));
+        return round((float) $size, $precision) . ' ' . ($next ? prev($units) : end($units));
     }
 
     /** Helper to return filesize (even bigger than 2Gb -linux only- and distant files size)


### PR DESCRIPTION
This can avoid getting errors in PHP 8:

```
round(): Argument #1 ($num) must be of type int|float, string given
```